### PR TITLE
fix:Could not find module education

### DIFF
--- a/whitelabel/api.py
+++ b/whitelabel/api.py
@@ -29,10 +29,11 @@ def update_onboard_details():
 def update_onboard_module():
 	onboard_module_details = frappe.get_all("Module Onboarding",filters={},fields=["name"])
 	for row in onboard_module_details:
-		doc = frappe.get_doc("Module Onboarding",row.name)
-		doc.documentation_url = ""
-		doc.flags.ignore_mandatory = True
-		doc.save(ignore_permissions = True)
+		if row.name != 'Education' or row.name != 'Education':
+			doc = frappe.get_doc("Module Onboarding",row.name)
+			doc.documentation_url = ""
+			doc.flags.ignore_mandatory = True
+			doc.save(ignore_permissions = True)
 
 def update_onborad_steps():
 	onboard_steps_details = frappe.get_all("Onboarding Step",filters={},fields=["name"])


### PR DESCRIPTION

when using *bench update --reset getting below erorr
frappe.exceptions.LinkValidationError: Could not find Module: Education

![Screenshot from 2023-07-11 20-46-39](https://github.com/jeewan2022/tunaerp-whitelabel/assets/110757180/580b453d-0ed2-476b-9b92-b938e72ecc39)

